### PR TITLE
[PRDP-180] feat: Avoid to retry receipt generation in case of missing property

### DIFF
--- a/src/main/java/it/gov/pagopa/receipt/pdf/generator/exception/ReceiptGenerationNotToRetryException.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/generator/exception/ReceiptGenerationNotToRetryException.java
@@ -1,0 +1,17 @@
+package it.gov.pagopa.receipt.pdf.generator.exception;
+
+/**
+ * Thrown in case the PDF Receipt generation fail with an error that is useless to be retried.
+ * Next generation will produce the same error.
+ */
+public class ReceiptGenerationNotToRetryException extends Exception {
+
+    /**
+     * Constructs new exception with provided message
+     *
+     * @param message Detail message
+     */
+    public ReceiptGenerationNotToRetryException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/it/gov/pagopa/receipt/pdf/generator/service/GenerateReceiptPdfService.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/generator/service/GenerateReceiptPdfService.java
@@ -2,6 +2,7 @@ package it.gov.pagopa.receipt.pdf.generator.service;
 
 import it.gov.pagopa.receipt.pdf.generator.entity.event.BizEvent;
 import it.gov.pagopa.receipt.pdf.generator.entity.receipt.Receipt;
+import it.gov.pagopa.receipt.pdf.generator.exception.ReceiptGenerationNotToRetryException;
 import it.gov.pagopa.receipt.pdf.generator.model.PdfGeneration;
 
 import java.nio.file.Path;
@@ -24,6 +25,7 @@ public interface GenerateReceiptPdfService {
      * @param receipt the Receipt that hold the status of the elaboration
      * @param pdfGeneration {@link PdfGeneration} object with the result of the PDF generation
      * @return true if the process succeeded, otherwise false
+     * @throws ReceiptGenerationNotToRetryException when the receipt generation fail with an error that will not be retried
      */
-    boolean verifyAndUpdateReceipt(Receipt receipt, PdfGeneration pdfGeneration);
+    boolean verifyAndUpdateReceipt(Receipt receipt, PdfGeneration pdfGeneration) throws ReceiptGenerationNotToRetryException;
 }


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Added logic to avoid receipt generation retry in case of specific errors

<!--- Describe your changes in detail -->

#### Motivation and Context
Avoid to retry receipt generation in case of missing property in BizEvent
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.