### PR TITLE
[PRDP-261] Updated RetryReviewedPoisonMessages function

### DIFF
--- a/integration-test/src/features/receipt_pdf_datastore.feature
+++ b/integration-test/src/features/receipt_pdf_datastore.feature
@@ -1,27 +1,29 @@
 Feature: All about payment events consumed by Azure functions receipt-pdf-generator
 
   Scenario: a biz event enqueued on receipts queue trigger the PDF receipt generation that is stored on receipts generator and blob storage
-    Given a receipt with id "receipt-generator-int-test-id-1" stored into receipt datastore
+    Given a receipt with id "receipt-generator-int-test-id-1" and status "INSERTED" stored into receipt datastore
     And a random biz event with id "receipt-generator-int-test-id-1" enqueued on receipts queue
     When the PDF receipt has been properly generate from biz event after 20000 ms
     Then the receipts datastore returns the receipt
     And the receipt has eventId "receipt-generator-int-test-id-1"
+    And the receipt has not the status "TO_REVIEW"
     And the receipt has not the status "NOT_QUEUE_SENT"
     And the receipt has not the status "INSERTED"
     And the blob storage has the PDF document
 
   Scenario: a biz event enqueued on receipts poison queue is enqueued on receipt queue that trigger the PDF receipt generation
-    Given a receipt with id "receipt-generator-int-test-id-2" stored into receipt datastore
+    Given a receipt with id "receipt-generator-int-test-id-2" and status "INSERTED" stored into receipt datastore
     And a random biz event with id "receipt-generator-int-test-id-2" enqueued on receipts poison queue with poison retry "false"
     When the PDF receipt has been properly generate from biz event after 20000 ms
     Then the receipts datastore returns the receipt
     And the receipt has eventId "receipt-generator-int-test-id-2"
+    And the receipt has not the status "TO_REVIEW"
     And the receipt has not the status "NOT_QUEUE_SENT"
     And the receipt has not the status "INSERTED"
     And the blob storage has the PDF document
 
   Scenario: a biz event enqueued on receipts poison queue is stored on receipt-message-error datastore and the receipt status is updated to TO_REVIEW
-    Given a receipt with id "receipt-generator-int-test-id-3" stored into receipt datastore
+    Given a receipt with id "receipt-generator-int-test-id-3" and status "INSERTED" stored into receipt datastore
     And a random biz event with id "receipt-generator-int-test-id-3" enqueued on receipts poison queue with poison retry "true"
     When the biz event has been properly stored on receipt-message-error datastore after 20000 ms
     Then the receipt-message-error datastore returns the error receipt
@@ -30,11 +32,12 @@ Feature: All about payment events consumed by Azure functions receipt-pdf-genera
     And the receipt has the status "TO_REVIEW"
 
   Scenario: a biz event stored on receipt-message-error is enqueued on receipt queue that trigger the PDF receipt generation
-    Given a receipt with id "receipt-generator-int-test-id-4" stored into receipt datastore
+    Given a receipt with id "receipt-generator-int-test-id-4" and status "TO_REVIEW" stored into receipt datastore
     And a error receipt with id "receipt-generator-int-test-id-4" stored into receipt-message-error datastore with status REVIEWED
     When the PDF receipt has been properly generate from biz event after 20000 ms
     Then the receipts datastore returns the receipt
     And the receipt has eventId "receipt-generator-int-test-id-4"
+    And the receipt has not the status "TO_REVIEW"
     And the receipt has not the status "NOT_QUEUE_SENT"
     And the receipt has not the status "INSERTED"
     And the blob storage has the PDF document

--- a/integration-test/src/step_definitions/common.js
+++ b/integration-test/src/step_definitions/common.js
@@ -126,7 +126,7 @@ function createEventForPoisonQueue(id, attemptedPoisonRetry) {
 	return json_event
 }
 
-function createReceipt(id) {
+function createReceipt(id, status) {
 	let receipt =
 	{
 		"eventId": id,
@@ -141,7 +141,7 @@ function createReceipt(id) {
 				}
 			]
 		},
-		"status": "INSERTED",
+		"status": status,
 		"numRetry": 0,
 		"id": id,
 		"_rid": "Z9AJAMdamqNjAAAAAAAAAA==",

--- a/integration-test/src/step_definitions/receipt_pdf_generator_step.js
+++ b/integration-test/src/step_definitions/receipt_pdf_generator_step.js
@@ -18,8 +18,8 @@ this.event = null;
 // After each Scenario
 After(async function () {
     // remove documents
-    if (this.eventId != null && this.receiptId != null) {
-        await deleteDocumentFromReceiptsDatastore(this.receiptId, this.eventId);
+    if (this.receiptId != null) {
+        await deleteDocumentFromReceiptsDatastore(this.receiptId);
     }
     if (this.errorReceiptId != null) {
         await deleteDocumentFromErrorReceiptsDatastore(this.errorReceiptId);
@@ -32,12 +32,12 @@ After(async function () {
 });
 
 
-Given('a receipt with id {string} stored into receipt datastore', async function (id) {
+Given('a receipt with id {string} and status {string} stored into receipt datastore', async function (id, status) {
     this.eventId = id;
     // prior cancellation to avoid dirty cases
-    await deleteDocumentFromReceiptsDatastore(this.eventId, this.eventId);
+    await deleteDocumentFromReceiptsDatastore(this.eventId);
 
-    let receiptsStoreResponse = await createDocumentInReceiptsDatastore(this.eventId);
+    let receiptsStoreResponse = await createDocumentInReceiptsDatastore(this.eventId, status);
     assert.strictEqual(receiptsStoreResponse.statusCode, 201);
     this.receiptId = this.eventId;
 });

--- a/integration-test/src/step_definitions/receipts_datastore_client.js
+++ b/integration-test/src/step_definitions/receipts_datastore_client.js
@@ -25,12 +25,12 @@ async function deleteDocumentFromReceiptsDatastoreByEventId(eventId){
     let documents = await getDocumentByIdFromReceiptsDatastore(eventId);
 
     documents?.resources?.forEach(el => {
-        deleteDocumentFromReceiptsDatastore(el.id, eventId);
+        deleteDocumentFromReceiptsDatastore(el.id);
     })
 }
 
-async function createDocumentInReceiptsDatastore(id) {
-    let receipt = createReceipt(id);
+async function createDocumentInReceiptsDatastore(id, status) {
+    let receipt = createReceipt(id, status);
     try {
         return await receiptContainer.items.create(receipt);
     } catch (err) {
@@ -38,9 +38,9 @@ async function createDocumentInReceiptsDatastore(id) {
     }
 }
 
-async function deleteDocumentFromReceiptsDatastore(id, partitionKey) {
+async function deleteDocumentFromReceiptsDatastore(id) {
     try {
-        return await receiptContainer.item(id, partitionKey).delete();
+        return await receiptContainer.item(id, id).delete();
     } catch (error) {
         if (error.code !== 404) {
             console.log(error)

--- a/src/main/java/it/gov/pagopa/receipt/pdf/generator/client/ReceiptCosmosClient.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/generator/client/ReceiptCosmosClient.java
@@ -1,9 +1,25 @@
 package it.gov.pagopa.receipt.pdf.generator.client;
 
+import com.azure.cosmos.models.CosmosItemResponse;
 import it.gov.pagopa.receipt.pdf.generator.entity.receipt.Receipt;
 import it.gov.pagopa.receipt.pdf.generator.exception.ReceiptNotFoundException;
 
 public interface ReceiptCosmosClient {
 
-    Receipt getReceiptDocument(String receiptId) throws ReceiptNotFoundException;
+    /**
+     * Retrieve receipt document from CosmosDB database
+     *
+     * @param eventId Biz-event id
+     * @return receipt document
+     * @throws ReceiptNotFoundException in case no receipt has been found with the given idEvent
+     */
+    Receipt getReceiptDocument(String eventId) throws ReceiptNotFoundException;
+
+    /**
+     * Save Receipts on CosmosDB database
+     *
+     * @param receipt Receipts to save
+     * @return receipt documents
+     */
+    CosmosItemResponse<Receipt> saveReceipt(Receipt receipt);
 }

--- a/src/main/java/it/gov/pagopa/receipt/pdf/generator/client/impl/ReceiptCosmosClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/generator/client/impl/ReceiptCosmosClientImpl.java
@@ -4,6 +4,7 @@ import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.cosmos.CosmosContainer;
 import com.azure.cosmos.CosmosDatabase;
+import com.azure.cosmos.models.CosmosItemResponse;
 import com.azure.cosmos.models.CosmosQueryRequestOptions;
 import com.azure.cosmos.util.CosmosPagedIterable;
 import it.gov.pagopa.receipt.pdf.generator.client.ReceiptCosmosClient;
@@ -45,12 +46,9 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
     }
 
     /**
-     * Retrieve receipt document from CosmosDB database
-     *
-     * @param eventId Biz-event id
-     * @return receipt document
-     * @throws ReceiptNotFoundException in case no receipt has been found with the given idEvent
+     * {@inheritDoc}
      */
+    @Override
     public Receipt getReceiptDocument(String eventId) throws ReceiptNotFoundException {
         CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
 
@@ -69,5 +67,17 @@ public class ReceiptCosmosClientImpl implements ReceiptCosmosClient {
             throw new ReceiptNotFoundException("Document not found in the defined container");
         }
 
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public CosmosItemResponse<Receipt> saveReceipt(Receipt receipt) {
+        CosmosDatabase cosmosDatabase = this.cosmosClient.getDatabase(databaseId);
+
+        CosmosContainer cosmosContainer = cosmosDatabase.getContainer(containerId);
+
+        return cosmosContainer.createItem(receipt);
     }
 }

--- a/src/main/java/it/gov/pagopa/receipt/pdf/generator/exception/UnableToSaveException.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/generator/exception/UnableToSaveException.java
@@ -1,0 +1,23 @@
+package it.gov.pagopa.receipt.pdf.generator.exception;
+
+public class UnableToSaveException extends Exception {
+
+    /**
+     * Constructs new exception with provided message and cause
+     *
+     * @param message Detail message
+     */
+    public UnableToSaveException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs new exception with provided message and cause
+     *
+     * @param message Detail message
+     * @param cause Exception thrown
+     */
+    public UnableToSaveException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/it/gov/pagopa/receipt/pdf/generator/exception/UnableToSaveException.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/generator/exception/UnableToSaveException.java
@@ -10,14 +10,4 @@ public class UnableToSaveException extends Exception {
     public UnableToSaveException(String message) {
         super(message);
     }
-
-    /**
-     * Constructs new exception with provided message and cause
-     *
-     * @param message Detail message
-     * @param cause Exception thrown
-     */
-    public UnableToSaveException(String message, Throwable cause) {
-        super(message, cause);
-    }
 }

--- a/src/main/java/it/gov/pagopa/receipt/pdf/generator/service/ReceiptCosmosService.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/generator/service/ReceiptCosmosService.java
@@ -2,6 +2,8 @@ package it.gov.pagopa.receipt.pdf.generator.service;
 
 import it.gov.pagopa.receipt.pdf.generator.entity.receipt.Receipt;
 import it.gov.pagopa.receipt.pdf.generator.exception.ReceiptNotFoundException;
+import it.gov.pagopa.receipt.pdf.generator.client.ReceiptCosmosClient;
+import it.gov.pagopa.receipt.pdf.generator.exception.UnableToSaveException;
 
 public interface ReceiptCosmosService {
 
@@ -12,4 +14,11 @@ public interface ReceiptCosmosService {
      * @throws ReceiptNotFoundException when no receipt has been found
      */
     Receipt getReceipt(String bizEventId) throws ReceiptNotFoundException;
+
+    /**
+     * Saves receipts on CosmosDB using {@link ReceiptCosmosClient}
+     *
+     * @param receipt Receipt to save
+     */
+    void saveReceipt(Receipt receipt) throws UnableToSaveException;
 }

--- a/src/main/java/it/gov/pagopa/receipt/pdf/generator/service/impl/ReceiptCosmosServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/generator/service/impl/ReceiptCosmosServiceImpl.java
@@ -51,7 +51,7 @@ public class ReceiptCosmosServiceImpl implements ReceiptCosmosService {
         int statusCode;
 
         try{
-            CosmosItemResponse<Receipt> response = receiptCosmosClient.saveReceipts(receipt);
+            CosmosItemResponse<Receipt> response = receiptCosmosClient.saveReceipt(receipt);
             statusCode = response.getStatusCode();
         }  catch (Exception e) {
             statusCode = HttpStatus.SC_INTERNAL_SERVER_ERROR;

--- a/src/main/java/it/gov/pagopa/receipt/pdf/generator/service/impl/ReceiptCosmosServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/generator/service/impl/ReceiptCosmosServiceImpl.java
@@ -1,13 +1,18 @@
 package it.gov.pagopa.receipt.pdf.generator.service.impl;
 
+import com.azure.cosmos.models.CosmosItemResponse;
 import it.gov.pagopa.receipt.pdf.generator.client.ReceiptCosmosClient;
 import it.gov.pagopa.receipt.pdf.generator.client.impl.ReceiptCosmosClientImpl;
 import it.gov.pagopa.receipt.pdf.generator.entity.receipt.Receipt;
 import it.gov.pagopa.receipt.pdf.generator.exception.ReceiptNotFoundException;
+import it.gov.pagopa.receipt.pdf.generator.exception.UnableToSaveException;
 import it.gov.pagopa.receipt.pdf.generator.service.ReceiptCosmosService;
+import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ReceiptCosmosServiceImpl implements ReceiptCosmosService {
-
+    private final Logger logger = LoggerFactory.getLogger(ReceiptCosmosServiceImpl.class);
     private final ReceiptCosmosClient receiptCosmosClient;
 
     public ReceiptCosmosServiceImpl() {
@@ -27,7 +32,7 @@ public class ReceiptCosmosServiceImpl implements ReceiptCosmosService {
         try {
             receipt = receiptCosmosClient.getReceiptDocument(bizEventId);
         } catch (ReceiptNotFoundException e) {
-            String errorMsg = String.format("Receipt not found with the biz-event id %s",bizEventId);
+            String errorMsg = String.format("Receipt not found with the biz-event id %s", bizEventId);
             throw new ReceiptNotFoundException(errorMsg, e);
         }
 
@@ -36,5 +41,26 @@ public class ReceiptCosmosServiceImpl implements ReceiptCosmosService {
             throw new ReceiptNotFoundException(errorMsg);
         }
         return receipt;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void saveReceipt(Receipt receipt) throws UnableToSaveException {
+        int statusCode;
+
+        try{
+            CosmosItemResponse<Receipt> response = receiptCosmosClient.saveReceipts(receipt);
+            statusCode = response.getStatusCode();
+        }  catch (Exception e) {
+            statusCode = HttpStatus.SC_INTERNAL_SERVER_ERROR;
+            logger.error(String.format("Save receipt with eventId %s on cosmos failed", receipt.getEventId()), e);
+        }
+
+        if(statusCode != com.microsoft.azure.functions.HttpStatus.CREATED.value()){
+            String errorMsg = String.format("Save receipt with eventId %s on cosmos failed with status %s", receipt.getEventId(), statusCode);
+            throw new UnableToSaveException(errorMsg);
+        }
     }
 }

--- a/src/test/java/it/gov/pagopa/receipt/pdf/generator/service/impl/ReceiptCosmosServiceImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/generator/service/impl/ReceiptCosmosServiceImplTest.java
@@ -1,0 +1,79 @@
+package it.gov.pagopa.receipt.pdf.generator.service.impl;
+
+import com.azure.cosmos.CosmosException;
+import com.azure.cosmos.models.CosmosItemResponse;
+import com.microsoft.azure.functions.HttpStatus;
+import it.gov.pagopa.receipt.pdf.generator.client.ReceiptCosmosClient;
+import it.gov.pagopa.receipt.pdf.generator.entity.receipt.Receipt;
+import it.gov.pagopa.receipt.pdf.generator.exception.ReceiptNotFoundException;
+import it.gov.pagopa.receipt.pdf.generator.exception.UnableToSaveException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReceiptCosmosServiceImplTest {
+
+    String BIZ_EVENT_ID = "valid biz event id";
+
+    @Mock
+    ReceiptCosmosClient receiptCosmosClient;
+    @Mock
+    CosmosItemResponse<Receipt> saveReceiptResponse;
+    ReceiptCosmosServiceImpl function;
+
+    @Test
+    void getReceiptSuccess() throws ReceiptNotFoundException {
+        when(receiptCosmosClient.getReceiptDocument(BIZ_EVENT_ID)).thenReturn(Receipt.builder().eventId(BIZ_EVENT_ID).build());
+
+        function = spy(new ReceiptCosmosServiceImpl(receiptCosmosClient));
+
+        AtomicReference<Receipt> response = new AtomicReference<>();
+        assertDoesNotThrow(() -> response.set(function.getReceipt(BIZ_EVENT_ID)));
+        assertEquals(BIZ_EVENT_ID,response.get().getEventId());
+    }
+    @Test
+    void getReceiptFailedWithReceiptNull() throws ReceiptNotFoundException {
+        when(receiptCosmosClient.getReceiptDocument(BIZ_EVENT_ID)).thenReturn(null);
+        function = spy(new ReceiptCosmosServiceImpl(receiptCosmosClient));
+        assertThrows(ReceiptNotFoundException.class, () -> function.getReceipt(BIZ_EVENT_ID));
+    }
+    @Test
+    void getReceiptFailedWithReceiptClientException() throws ReceiptNotFoundException {
+        when(receiptCosmosClient.getReceiptDocument(BIZ_EVENT_ID)).thenThrow(ReceiptNotFoundException.class);
+        function = spy(new ReceiptCosmosServiceImpl(receiptCosmosClient));
+        assertThrows(ReceiptNotFoundException.class, () -> function.getReceipt(BIZ_EVENT_ID));
+    }
+
+    @Test
+    void saveReceiptSuccess(){
+        Receipt receipt = Receipt.builder().eventId(BIZ_EVENT_ID).build();
+        when(saveReceiptResponse.getStatusCode()).thenReturn(HttpStatus.CREATED.value());
+        when(receiptCosmosClient.saveReceipt(receipt)).thenReturn(saveReceiptResponse);
+        function = spy(new ReceiptCosmosServiceImpl(receiptCosmosClient));
+        assertDoesNotThrow(() -> function.saveReceipt(receipt));
+    }
+    @Test
+    void saveReceiptFailedNotCreated(){
+        Receipt receipt = Receipt.builder().eventId(BIZ_EVENT_ID).build();
+        when(saveReceiptResponse.getStatusCode()).thenReturn(HttpStatus.I_AM_A_TEAPOT.value());
+        when(receiptCosmosClient.saveReceipt(receipt)).thenReturn(saveReceiptResponse);
+        function = spy(new ReceiptCosmosServiceImpl(receiptCosmosClient));
+        assertThrows(UnableToSaveException.class,() -> function.saveReceipt(receipt));
+    }
+    @Test
+    void saveReceiptFailedWithReceiptClientException(){
+        Receipt receipt = Receipt.builder().eventId(BIZ_EVENT_ID).build();
+        when(receiptCosmosClient.saveReceipt(receipt)).thenThrow(CosmosException.class);
+        function = spy(new ReceiptCosmosServiceImpl(receiptCosmosClient));
+        assertThrows(UnableToSaveException.class,() -> function.saveReceipt(receipt));
+    }
+
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
- Implemented method to save receipt to cosmosDB
- Updated RetryReviewedPoisonMessages logic to search receipt relative to poison bizEvent and update its status from TO_REVIEW to INSERT
- Updated unit tests
- Improved integration tests with more control on receipt status

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
[Issue PRDP-261](https://pagopa.atlassian.net/browse/PRDP-261?atlOrigin=eyJpIjoiNzc5NWZkYzBmMDVlNDAzYjkwZTljZmFmYjBjMTg5MTMiLCJwIjoiaiJ9)

Relates to [PR-91](https://github.com/pagopa/pagopa-receipt-pdf-generator/pull/91)

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.