### PR TITLE
[PIDM-862] notify app io

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopareceiptpdfgenerator
 description: Microservice description
 type: application
-version: 0.226.0
-appVersion: 1.17.19
+version: 0.227.0
+appVersion: 1.17.20-PIDM-862-notify-appIO
 dependencies:
   - name: microservice-chart
     version: 8.0.2

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart: &microservice-chart
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-receipt-pdf-generator
-    tag: "1.17.19"
+    tag: "1.17.20-PIDM-862-notify-appIO"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   livenessProbe:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart: &microservice-chart
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-receipt-pdf-generator
-    tag: "1.17.19"
+    tag: "1.17.20-PIDM-862-notify-appIO"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   livenessProbe:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart: &microservice-chart
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-receipt-pdf-generator
-    tag: "1.17.19"
+    tag: "1.17.20-PIDM-862-notify-appIO"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   livenessProbe:

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "title": "Receipts Generator Helpdesk",
     "description": "Microservice for exposing REST APIs about receipts helpdesk.",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.17.19"
+    "version": "1.17.20-PIDM-862-notify-appIO"
   },
   "servers": [
     {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa.receipt</groupId>
     <artifactId>receipt-pdf-generator</artifactId>
-    <version>1.17.19</version>
+    <version>1.17.20-PIDM-862-notify-appIO</version>
     <packaging>jar</packaging>
 
     <name>pagopa-receipt-pdf-generator</name>

--- a/src/main/java/it/gov/pagopa/receipt/pdf/generator/GenerateReceiptPdf.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/generator/GenerateReceiptPdf.java
@@ -177,7 +177,11 @@ public class GenerateReceiptPdf {
         try {
             success = this.generateReceiptPdfService.verifyAndUpdateReceipt(receipt, pdfGeneration);
             if (success) {
-                receipt.setStatus(ReceiptStatusType.GENERATED);
+                if (Boolean.FALSE.equals(receipt.getSendNotification())) {
+                    receipt.setStatus(ReceiptStatusType.NOT_TO_NOTIFY);
+                } else {
+                    receipt.setStatus(ReceiptStatusType.GENERATED);
+                }
                 receipt.setGenerated_at(System.currentTimeMillis());
                 logger.info("[{}] Receipt with id {} being saved with status {}",
                         context.getFunctionName(),

--- a/src/main/java/it/gov/pagopa/receipt/pdf/generator/entity/receipt/Receipt.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/generator/entity/receipt/Receipt.java
@@ -24,4 +24,5 @@ public class Receipt {
     private long inserted_at;
     private long generated_at;
     private long notified_at;
+    private Boolean sendNotification;
 }

--- a/src/test/java/it/gov/pagopa/receipt/pdf/generator/GenerateReceiptPdfTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/generator/GenerateReceiptPdfTest.java
@@ -268,6 +268,33 @@ class GenerateReceiptPdfTest {
         verify(queueServiceMock, never()).sendMessageToQueue(any());
     }
 
+    @Test
+    @SneakyThrows
+    void generatePDFReceiptSuccessWithSendNotificationFalseStatusNotToNotify() {
+        int numRetry = 0;
+        Receipt receipt = buildReceiptWithStatus(ReceiptStatusType.INSERTED, numRetry, BIZ_EVENT_ID_FIRST);
+        receipt.setSendNotification(false);
+
+        doReturn(receipt).when(receiptCosmosServiceMock).getReceipt(anyString());
+        doReturn(new PdfGeneration()).when(generateReceiptPdfServiceMock).generateReceipts(any(), any(), any());
+        doReturn(true).when(generateReceiptPdfServiceMock).verifyAndUpdateReceipt(any(), any());
+
+        sut.processGenerateReceipt(BIZ_EVENT_VALID_MESSAGE, documentReceiptsMock, executionContextMock);
+
+        assertEquals(ReceiptStatusType.NOT_TO_NOTIFY, receipt.getStatus());
+        assertNotEquals(ORIGINAL_GENERATED_AT, receipt.getGenerated_at());
+        assertEquals(numRetry, receipt.getNumRetry());
+        assertNull(receipt.getReasonErr());
+        assertEquals(BIZ_EVENT_ID_FIRST, receipt.getEventId());
+
+        verify(receiptCosmosServiceMock).getReceipt(anyString());
+        verify(generateReceiptPdfServiceMock).generateReceipts(any(), any(), any());
+        verify(generateReceiptPdfServiceMock).verifyAndUpdateReceipt(any(), any());
+        verify(documentReceiptsMock).setValue(any());
+        verify(queueServiceMock, never()).sendMessageToQueue(any());
+    }
+
+
     private Receipt buildReceiptWithStatus(ReceiptStatusType receiptStatusType, int numRetry, String id) {
         return Receipt.builder()
                 .eventData(EventData.builder()


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- After a successful PDF generation, the receipt status is now set based on the `sendNotification` flag on the receipt:
  - `sendNotification=false` → the receipt is saved with the new `NOT_TO_NOTIFY` status;
  - `sendNotification=true` or not set → the receipt is saved with the `GENERATED` status, as before.
- Added unit tests in `GenerateReceiptPdfTest` covering both cases: receipt saved with `NOT_TO_NOTIFY` when `sendNotification=false`, and with `GENERATED` when the flag is `true`.


#### Motivation and Context

The receipt recovery APIs exposed by the `pagopa-receipt-pdf-helpdesk` microservice are being extended with an optional `sendNotification` parameter, allowing the Assistance team to decide at execution time whether a recovered receipt should trigger the notification to the IO app. The parameter defaults to `true`, so the current behavior of the existing APIs remains unchanged; in case of massive recovery of historical receipts, the Assistance team will be able to call the API with `sendNotification=false`, avoiding unwanted notifications to end users for old payments.

The choice made by the helpdesk API is persisted on the receipt before it is sent to the PDF generation queue. This PR updates the `pagopa-receipt-pdf-generator` microservice accordingly, since it consumes the queue and updates the receipt status after PDF generation:

* if `sendNotification` is `true` or not set, the receipt keeps being moved to the `GENERATED` status, preserving the current behavior;
* if `sendNotification` is `false`, the receipt is moved to the `NOT_TO_NOTIFY` status, so that the PDF is considered correctly generated without triggering the subsequent notification flow to the IO app.

This way the recovery API remains backward compatible, while allowing massive recoveries of old receipts to be handled correctly. Companion change on the helpdesk side: see the PR on `pagopa-receipt-pdf-helpdesk` (PIDM-862).


#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.