### PR TITLE
chore: [PAGOPA-3722] Tuning client PDF Engine

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopareceiptpdfgenerator
 description: Microservice description
 type: application
-version: 0.226.0
-appVersion: 1.17.19
+version: 0.227.0
+appVersion: 1.17.19-1-PAGOPA-3722-tuning-client-pdf-engine
 dependencies:
   - name: microservice-chart
     version: 8.0.2

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart: &microservice-chart
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-receipt-pdf-generator
-    tag: "1.17.19"
+    tag: "1.17.19-1-PAGOPA-3722-tuning-client-pdf-engine"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   livenessProbe:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart: &microservice-chart
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-receipt-pdf-generator
-    tag: "1.17.19"
+    tag: "1.17.19-1-PAGOPA-3722-tuning-client-pdf-engine"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   livenessProbe:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart: &microservice-chart
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-receipt-pdf-generator
-    tag: "1.17.19"
+    tag: "1.17.19-1-PAGOPA-3722-tuning-client-pdf-engine"
     pullPolicy: Always
   # https://github.com/Azure/azure-functions-host/blob/dev/src/WebJobs.Script.WebHost/Controllers/HostController.cs
   livenessProbe:

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "title": "Receipts Generator Helpdesk",
     "description": "Microservice for exposing REST APIs about receipts helpdesk.",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.17.19"
+    "version": "1.17.19-1-PAGOPA-3722-tuning-client-pdf-engine"
   },
   "servers": [
     {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa.receipt</groupId>
     <artifactId>receipt-pdf-generator</artifactId>
-    <version>1.17.19</version>
+    <version>1.17.19-1-PAGOPA-3722-tuning-client-pdf-engine</version>
     <packaging>jar</packaging>
 
     <name>pagopa-receipt-pdf-generator</name>

--- a/src/main/java/it/gov/pagopa/receipt/pdf/generator/client/impl/PdfEngineClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/generator/client/impl/PdfEngineClientImpl.java
@@ -59,16 +59,27 @@ public class PdfEngineClientImpl implements PdfEngineClient {
             System.getenv().getOrDefault("OCP_APIM_SUBSCRIPTION_KEY", ""));
 
     // ---------- HTTP timeouts (ms) ----------
+    // Apache HttpClient defaults are -1 (infinite).
+    /** Max time to establish TCP+TLS connection. */
     private static final int CONNECT_TIMEOUT_MS = envInt("PDF_ENGINE_HTTP_CONNECT_TIMEOUT_MS", 5_000);
+    /** Max wait to lease a connection from the pool. Fail fast when pool is saturated. */
     private static final int CONNECTION_REQUEST_TIMEOUT_MS = envInt("PDF_ENGINE_HTTP_CONN_REQUEST_TIMEOUT_MS", 2_000);
+    /** SO_TIMEOUT: max inactivity while reading the response. */
     private static final int SOCKET_TIMEOUT_MS = envInt("PDF_ENGINE_HTTP_SOCKET_TIMEOUT_MS", 30_000);
+    /** Retries on transient I/O errors (see {@link #buildRetryHandler()}). */
     private static final int RETRY_COUNT = envInt("PDF_ENGINE_HTTP_RETRY_COUNT", 2);
 
     // ---------- Connection pool ----------
+    // HttpClient defaults are maxTotal=20, maxPerRoute=2.
+    /** Max concurrent connections to the PDF Engine route. Size on per-JVM concurrency peak. */
     private static final int MAX_CONN_PER_ROUTE = envInt("PDF_ENGINE_HTTP_MAX_CONN_PER_ROUTE", 80);
+    /** Pool cap. Single route here, so aligned with {@link #MAX_CONN_PER_ROUTE}. */
     private static final int MAX_CONN_TOTAL = envInt("PDF_ENGINE_HTTP_MAX_CONN_TOTAL", MAX_CONN_PER_ROUTE);
+    /** Connection TTL (s). Keep below APIM keep-alive to avoid stale sockets. */
     private static final long CONN_TTL_SECONDS = envLong("PDF_ENGINE_HTTP_CONN_TTL_SECONDS", 60L);
+    /** Idle eviction interval (s). Should stay below {@link #CONN_TTL_SECONDS}. */
     private static final long IDLE_EVICT_SECONDS = envLong("PDF_ENGINE_HTTP_IDLE_EVICT_SECONDS", 30L);
+    /** Validate leased connection if idle longer than this (ms). Matches HttpClient default, made explicit. */
     private static final int VALIDATE_AFTER_INACTIVITY_MS = envInt("PDF_ENGINE_HTTP_VALIDATE_AFTER_INACTIVITY_MS", 2_000);
 
     /**
@@ -280,10 +291,9 @@ public class PdfEngineClientImpl implements PdfEngineClient {
     }
 
     /**
-     * Retry handler: retries on transient I/O failures (connect timeouts,
-     * dropped keep-alive connections, read timeouts) but NOT on auth/SSL or
-     * unknown-host errors. Critical to absorb single hiccups on APIM without
-     * surfacing them as HTTP 500 to the caller.
+     * Retry handler for transient I/O failures on APIM (connect timeouts, dropped keep-alive,
+     * read timeouts). Excludes non-transient errors (auth/SSL/unknown host). Note: retries on
+     * {@link SocketTimeoutException} assume PDF Engine is idempotent — disable if not.
      */
     private static DefaultHttpRequestRetryHandler buildRetryHandler() {
         return new DefaultHttpRequestRetryHandler(

--- a/src/main/java/it/gov/pagopa/receipt/pdf/generator/client/impl/PdfEngineClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/generator/client/impl/PdfEngineClientImpl.java
@@ -7,24 +7,37 @@ import it.gov.pagopa.receipt.pdf.generator.model.response.PdfEngineResponse;
 import it.gov.pagopa.receipt.pdf.generator.utils.ObjectMapperUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
+import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
+import org.apache.http.NoHttpResponseException;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.conn.ConnectTimeoutException;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.mime.HttpMultipartMode;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.entity.mime.content.StringBody;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.message.BasicHeader;
 import org.apache.http.util.EntityUtils;
 
+import javax.net.ssl.SSLException;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
+import java.net.SocketTimeoutException;
 import java.net.URL;
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static it.gov.pagopa.receipt.pdf.generator.utils.Constants.ZIP_FILE_NAME;
 
@@ -34,36 +47,52 @@ import static it.gov.pagopa.receipt.pdf.generator.utils.Constants.ZIP_FILE_NAME;
 @Slf4j
 public class PdfEngineClientImpl implements PdfEngineClient {
 
-    private final String pdfEngineEndpoint = System.getenv().getOrDefault("PDF_ENGINE_ENDPOINT", "");
-    private final String ocpAimSubKey = System.getenv().getOrDefault("OCP_APIM_SUBSCRIPTION_KEY", "");
-
     private static final String HEADER_AUTH_KEY = "Ocp-Apim-Subscription-Key";
     private static final String TEMPLATE_KEY = "template";
     private static final String DATA_KEY = "data";
 
     private static final URL TEMPLATE_STREAM = PdfEngineClientImpl.class.getClassLoader().getResource(ZIP_FILE_NAME);
 
+    private final String pdfEngineEndpoint = System.getenv().getOrDefault("PDF_ENGINE_ENDPOINT", "");
+    private final Header subKeyHeader = new BasicHeader(
+            HEADER_AUTH_KEY,
+            System.getenv().getOrDefault("OCP_APIM_SUBSCRIPTION_KEY", ""));
 
-    private final CloseableHttpClient client;
+    // ---------- HTTP timeouts (ms) ----------
+    private static final int CONNECT_TIMEOUT_MS = envInt("PDF_ENGINE_HTTP_CONNECT_TIMEOUT_MS", 5_000);
+    private static final int CONNECTION_REQUEST_TIMEOUT_MS = envInt("PDF_ENGINE_HTTP_CONN_REQUEST_TIMEOUT_MS", 2_000);
+    private static final int SOCKET_TIMEOUT_MS = envInt("PDF_ENGINE_HTTP_SOCKET_TIMEOUT_MS", 30_000);
+    private static final int RETRY_COUNT = envInt("PDF_ENGINE_HTTP_RETRY_COUNT", 2);
 
-    private PdfEngineClientImpl() {
-        this.client = HttpClientBuilder.create().build();
-    }
-
-    PdfEngineClientImpl(CloseableHttpClient client) {
-        this.client = client;
-    }
+    // ---------- Connection pool ----------
+    private static final int MAX_CONN_PER_ROUTE = envInt("PDF_ENGINE_HTTP_MAX_CONN_PER_ROUTE", 80);
+    private static final int MAX_CONN_TOTAL = envInt("PDF_ENGINE_HTTP_MAX_CONN_TOTAL", MAX_CONN_PER_ROUTE);
+    private static final long CONN_TTL_SECONDS = envLong("PDF_ENGINE_HTTP_CONN_TTL_SECONDS", 60L);
+    private static final long IDLE_EVICT_SECONDS = envLong("PDF_ENGINE_HTTP_IDLE_EVICT_SECONDS", 30L);
+    private static final int VALIDATE_AFTER_INACTIVITY_MS = envInt("PDF_ENGINE_HTTP_VALIDATE_AFTER_INACTIVITY_MS", 2_000);
 
     /**
-     * Bill Pugh singleton holder: the JVM guarantees that the class is loaded
-     * (and therefore INSTANCE initialized) lazily and in a thread-safe way.
+     * Long-lived, thread-safe pooled HTTP client.
      */
-    private static class SingletonHelper {
+    private final CloseableHttpClient httpClient;
+
+    private static final class Holder {
         private static final PdfEngineClientImpl INSTANCE = new PdfEngineClientImpl();
     }
 
     public static PdfEngineClientImpl getInstance() {
-        return SingletonHelper.INSTANCE;
+        return Holder.INSTANCE;
+    }
+
+    private PdfEngineClientImpl() {
+        this(buildDefaultHttpClient());
+    }
+
+    /**
+     * Visible for tests: allows injecting a mocked or custom client.
+     */
+    protected PdfEngineClientImpl(CloseableHttpClient httpClient) {
+        this.httpClient = httpClient;
     }
 
     /**
@@ -85,19 +114,22 @@ public class PdfEngineClientImpl implements PdfEngineClient {
         }
     }
 
-    private HttpPost buildMultipartRequest(PdfEngineRequest pdfEngineRequest, InputStream templateStream) throws IOException {
+    private HttpPost buildMultipartRequest(
+            PdfEngineRequest pdfEngineRequest,
+            InputStream templateStream
+    ) throws IOException {
         StringBody dataBody = new StringBody(pdfEngineRequest.getData(), ContentType.APPLICATION_JSON);
 
         //Build the multipart request
-        MultipartEntityBuilder builder = MultipartEntityBuilder.create();
-        builder.setMode(HttpMultipartMode.BROWSER_COMPATIBLE);
-        builder.addBinaryBody(TEMPLATE_KEY, templateStream.readAllBytes(), ContentType.create("application/zip"), ZIP_FILE_NAME);
-        builder.addPart(DATA_KEY, dataBody);
-        HttpEntity entity = builder.build();
+        HttpEntity entity = MultipartEntityBuilder.create()
+                .setMode(HttpMultipartMode.BROWSER_COMPATIBLE)
+                .addBinaryBody(TEMPLATE_KEY, templateStream.readAllBytes(), ContentType.create("application/zip"), ZIP_FILE_NAME)
+                .addPart(DATA_KEY, dataBody)
+                .build();
 
         //Set endpoint and auth key
         HttpPost request = new HttpPost(pdfEngineEndpoint);
-        request.setHeader(HEADER_AUTH_KEY, ocpAimSubKey);
+        request.setHeader(subKeyHeader);
         request.setEntity(entity);
         return request;
     }
@@ -111,7 +143,7 @@ public class PdfEngineClientImpl implements PdfEngineClient {
     private PdfEngineResponse makeCall(HttpPost request, Path workingDirPath) {
         PdfEngineResponse pdfEngineResponse = new PdfEngineResponse();
         //Execute call
-        try (CloseableHttpResponse response = this.client.execute(request)) {
+        try (CloseableHttpResponse response = this.httpClient.execute(request)) {
             //Retrieve response
             int statusCode = response.getStatusLine().getStatusCode();
             HttpEntity entityResponse = response.getEntity();
@@ -213,5 +245,80 @@ public class PdfEngineClientImpl implements PdfEngineClient {
         pdfEngineResponse.setStatusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
         pdfEngineResponse.setErrorMessage(errMsg);
         return pdfEngineResponse;
+    }
+
+    // -----------------------------------------------------------------
+    // HTTP client construction
+    // -----------------------------------------------------------------
+
+    /**
+     * Builds the shared {@link CloseableHttpClient} with a pooled connection
+     * manager, sensible timeouts and a retry handler for transient I/O errors.
+     */
+    private static CloseableHttpClient buildDefaultHttpClient() {
+        PoolingHttpClientConnectionManager connectionManager =
+                new PoolingHttpClientConnectionManager(CONN_TTL_SECONDS, TimeUnit.SECONDS);
+        connectionManager.setMaxTotal(MAX_CONN_TOTAL);
+        connectionManager.setDefaultMaxPerRoute(MAX_CONN_PER_ROUTE);
+        connectionManager.setValidateAfterInactivity(VALIDATE_AFTER_INACTIVITY_MS);
+
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectTimeout(CONNECT_TIMEOUT_MS)
+                .setConnectionRequestTimeout(CONNECTION_REQUEST_TIMEOUT_MS)
+                .setSocketTimeout(SOCKET_TIMEOUT_MS)
+                .build();
+
+        return HttpClientBuilder.create()
+                .setConnectionManager(connectionManager)
+                .setConnectionManagerShared(false)
+                .setDefaultRequestConfig(requestConfig)
+                .setRetryHandler(buildRetryHandler())
+                .setConnectionTimeToLive(CONN_TTL_SECONDS, TimeUnit.SECONDS)
+                .evictExpiredConnections()
+                .evictIdleConnections(IDLE_EVICT_SECONDS, TimeUnit.SECONDS)
+                .build();
+    }
+
+    /**
+     * Retry handler: retries on transient I/O failures (connect timeouts,
+     * dropped keep-alive connections, read timeouts) but NOT on auth/SSL or
+     * unknown-host errors. Critical to absorb single hiccups on APIM without
+     * surfacing them as HTTP 500 to the caller.
+     */
+    private static DefaultHttpRequestRetryHandler buildRetryHandler() {
+        return new DefaultHttpRequestRetryHandler(
+                RETRY_COUNT,
+                true,
+                List.of(InterruptedIOException.class, UnknownHostException.class, SSLException.class)
+        ) {
+            @Override
+            public boolean retryRequest(
+                    IOException exception,
+                    int executionCount,
+                    org.apache.http.protocol.HttpContext context
+            ) {
+                if (executionCount > RETRY_COUNT) {
+                    return false;
+                }
+                if (exception instanceof ConnectTimeoutException
+                        || exception instanceof NoHttpResponseException
+                        || exception instanceof SocketTimeoutException) {
+                    return true;
+                }
+                return super.retryRequest(exception, executionCount, context);
+            }
+        };
+    }
+
+    // -----------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------
+
+    private static int envInt(String name, int defaultValue) {
+        return Integer.parseInt(System.getenv().getOrDefault(name, Integer.toString(defaultValue)));
+    }
+
+    private static long envLong(String name, long defaultValue) {
+        return Long.parseLong(System.getenv().getOrDefault(name, Long.toString(defaultValue)));
     }
 }

--- a/src/main/java/it/gov/pagopa/receipt/pdf/generator/client/impl/PdfEngineClientImpl.java
+++ b/src/main/java/it/gov/pagopa/receipt/pdf/generator/client/impl/PdfEngineClientImpl.java
@@ -72,7 +72,7 @@ public class PdfEngineClientImpl implements PdfEngineClient {
     // ---------- Connection pool ----------
     // HttpClient defaults are maxTotal=20, maxPerRoute=2.
     /** Max concurrent connections to the PDF Engine route. Size on per-JVM concurrency peak. */
-    private static final int MAX_CONN_PER_ROUTE = envInt("PDF_ENGINE_HTTP_MAX_CONN_PER_ROUTE", 80);
+    private static final int MAX_CONN_PER_ROUTE = envInt("PDF_ENGINE_HTTP_MAX_CONN_PER_ROUTE", 50);
     /** Pool cap. Single route here, so aligned with {@link #MAX_CONN_PER_ROUTE}. */
     private static final int MAX_CONN_TOTAL = envInt("PDF_ENGINE_HTTP_MAX_CONN_TOTAL", MAX_CONN_PER_ROUTE);
     /** Connection TTL (s). Keep below APIM keep-alive to avoid stale sockets. */

--- a/src/test/java/it/gov/pagopa/receipt/pdf/generator/client/impl/PdfEngineClientImplTest.java
+++ b/src/test/java/it/gov/pagopa/receipt/pdf/generator/client/impl/PdfEngineClientImplTest.java
@@ -8,9 +8,14 @@ import it.gov.pagopa.receipt.pdf.generator.model.template.ReceiptPDFTemplate;
 import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
+import org.apache.http.NoHttpResponseException;
 import org.apache.http.StatusLine;
+import org.apache.http.client.HttpRequestRetryHandler;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.conn.ConnectTimeoutException;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.protocol.BasicHttpContext;
+import org.apache.http.protocol.HttpContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,11 +25,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import javax.net.ssl.SSLException;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
+import java.io.InterruptedIOException;
+import java.lang.reflect.Method;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -191,9 +200,55 @@ class PdfEngineClientImplTest {
         assertTrue(result.getErrorMessage().startsWith("Exception thrown during pdf generation process:"));
     }
 
-    private PdfEngineRequest buildPdfEngineRequest() throws MalformedURLException, JsonProcessingException {
+    @Test
+    void retryHandlerRetriesOnConnectTimeout() throws Exception {
+        HttpRequestRetryHandler handler = retryHandler();
+        HttpContext ctx = new BasicHttpContext();
+
+        assertTrue(handler.retryRequest(new ConnectTimeoutException("timeout"), 1, ctx));
+        assertTrue(handler.retryRequest(new ConnectTimeoutException("timeout"), 2, ctx));
+    }
+
+    @Test
+    void retryHandlerRetriesOnNoHttpResponse() throws Exception {
+        HttpRequestRetryHandler handler = retryHandler();
+        assertTrue(handler.retryRequest(new NoHttpResponseException("stale keep-alive"), 1, new BasicHttpContext()));
+    }
+
+    @Test
+    void retryHandlerRetriesOnSocketTimeout() throws Exception {
+        HttpRequestRetryHandler handler = retryHandler();
+        assertTrue(handler.retryRequest(new SocketTimeoutException("read timeout"), 1, new BasicHttpContext()));
+    }
+
+    @Test
+    void retryHandlerStopsAfterMaxAttempts() throws Exception {
+        HttpRequestRetryHandler handler = retryHandler();
+        // RETRY_COUNT default is 2, so executionCount=3 must not retry
+        assertFalse(handler.retryRequest(new ConnectTimeoutException("timeout"), 3, new BasicHttpContext()));
+    }
+
+    @Test
+    void retryHandlerDoesNotRetryOnNonTransientErrors() throws Exception {
+        HttpRequestRetryHandler handler = retryHandler();
+        HttpContext ctx = new BasicHttpContext();
+
+        // Excluded classes in DefaultHttpRequestRetryHandler must not be retried.
+        assertFalse(handler.retryRequest(new SSLException("handshake failed"), 1, ctx));
+        assertFalse(handler.retryRequest(new UnknownHostException("dns"), 1, ctx));
+        // Generic InterruptedIOException is in the non-retriable list too.
+        assertFalse(handler.retryRequest(new InterruptedIOException("interrupted"), 1, ctx));
+    }
+
+    private PdfEngineRequest buildPdfEngineRequest() throws JsonProcessingException {
         return PdfEngineRequest.builder()
                 .data(objectMapper.writeValueAsString(new ReceiptPDFTemplate()))
                 .build();
+    }
+
+    private static HttpRequestRetryHandler retryHandler() throws Exception {
+        Method m = PdfEngineClientImpl.class.getDeclaredMethod("buildRetryHandler");
+        m.setAccessible(true);
+        return (HttpRequestRetryHandler) m.invoke(null);
     }
 }


### PR DESCRIPTION
#### List of Changes

- Introduce explicit, environment-overridable configuration for:
  - HTTP timeouts: `connectTimeout` (5s), `connectionRequestTimeout` (2s), `socketTimeout` (30s).
  - Connection pool: `maxTotal` / `maxPerRoute` (50), connection TTL (60s), idle eviction (30s), validate-after-inactivity (2s).
  - Retry policy: 2 retries with a custom `DefaultHttpRequestRetryHandler` that retries on `ConnectTimeoutException`, `NoHttpResponseException`, `SocketTimeoutException` and excludes non-transient errors (`SSLException`, `UnknownHostException`, `InterruptedIOException`).
- Add concise inline documentation for each tunable so future adjustments are straightforward.

#### Motivation and Context

The previous client relied entirely on Apache HttpClient 4.x defaults, which are unsuitable for srevice SLA:

- All timeouts defaulted to `-1` (infinite): a single upstream hiccup on APIM / PDF Engine could park worker threads indefinitely and propagate as HTTP 500 to the caller.
- `PoolingHttpClientConnectionManager` defaults are `maxTotal=20`, `maxPerRoute=2`, which throttled concurrency well below the queue-trigger `batchSize` (32) and caused unnecessary contention.
- No idle/expired connection eviction, leading to reuse of stale keep-alive sockets already closed by APIM (typical root cause of sporadic `NoHttpResponseException`).
- The default retry handler does not retry `ConnectTimeoutException` nor connections dropped mid keep-alive, so transient network glitches surfaced as errors instead of being absorbed.

The new configuration aligns the client with the effective concurrency of the Function , keeping the pool slightly oversized and bounding all failure paths with finite timeouts.

#### How Has This Been Tested?


#### Screenshots (if appropriate):


#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.